### PR TITLE
Add City Cards with Weather Data

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,9 @@ import logo from "./assets/icons/logo.png";
 import PullToRefreshComponent from "./Components/PullToRefreshComponent";
 import { Routes, Route } from "react-router-dom";
 import NotFound from "./Components/404";
+import CityCard from "./Components/CityCards";
+
+const cities = ["Delhi", "Jaipur", "Kolkata"];
 
 function App() {
   const { weather, thisLocation, values, place, setPlace, fetchWeather } =
@@ -20,6 +23,10 @@ function App() {
 
   const handleRefresh = async () => {
     console.log("Refreshing weather data...");
+    await fetchWeather();
+  };
+  const handleCityClick = async (city) => {
+    setPlace(city);
     await fetchWeather();
   };
 
@@ -42,32 +49,44 @@ function App() {
       </nav>
 
       <BackgroundLayout />
+
       <PullToRefreshComponent onRefresh={handleRefresh}>
         <Routes>
           <Route
             path="/"
             element={
-              <main className="w-full flex flex-wrap mt-20  lg:mt-40 gap-8 py-4 px-[5%] sm:px-[10%] items-center justify-center">
-                <WeatherCard
-                  place={thisLocation}
-                  windspeed={weather.wspd}
-                  humidity={weather.humidity}
-                  temperature={weather.temp}
-                  heatIndex={weather.heatindex}
-                  iconString={weather.conditions}
-                  conditions={weather.conditions}
-                  isCelsius={unit === "C"}
-                />
-                <div className="flex justify-center gap-8 flex-wrap w-full sm:w-[60%] ">
-                  {values?.slice(1, 7).map((curr) => (
-                    <MiniCard
-                      key={curr.datetime}
-                      time={curr.datetime}
-                      temp={convertTemperature(curr.temp)}
-                      iconString={curr.conditions}
-                      isCelsius={unit === "C"}
+              <main className="w-full flex flex-wrap mt-10  lg:mt-40 gap-2 py-4 px-[5%] sm:px-[10%] items-center justify-center">
+                <div className="hidden lg:flex justify-center gap-8 flex-wrap w-full sm:w-[40%]">
+                  {cities.map((city) => (
+                    <CityCard
+                      key={city}
+                      city={city}
+                      onClick={() => handleCityClick(city)}
                     />
                   ))}
+                </div>
+                <div className="flex flex-col lg:flex-row gap-8 lg:gap-8 p-8 lg:p-0 justify-center items-center">
+                  <WeatherCard
+                    place={thisLocation}
+                    windspeed={weather.wspd}
+                    humidity={weather.humidity}
+                    temperature={weather.temp}
+                    heatIndex={weather.heatindex}
+                    iconString={weather.conditions}
+                    conditions={weather.conditions}
+                    isCelsius={unit === "C"}
+                  />
+                  <div className="flex justify-center gap-8 flex-wrap w-full sm:w-[60%] ">
+                    {values?.slice(1, 7).map((curr) => (
+                      <MiniCard
+                        key={curr.datetime}
+                        time={curr.datetime}
+                        temp={convertTemperature(curr.temp)}
+                        iconString={curr.conditions}
+                        isCelsius={unit === "C"}
+                      />
+                    ))}
+                  </div>
                 </div>
               </main>
             }

--- a/src/Components/CityCards.jsx
+++ b/src/Components/CityCards.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+const CityCard = ({ city, onClick }) => {
+  return (
+    <div
+      onClick={onClick}
+      className="city-card glassCard w-[8rem] h-[3rem] p-2 cursor-pointer flex flex-col justify-center items-center text-center opacity-75 hover:opacity-100 transition-opacity"
+    >
+      <p className="font-bold text-lg">{city}</p>
+    </div>
+  );
+};
+
+export default CityCard;


### PR DESCRIPTION
This pull request adds city cards that display current weather data for multiple cities. Each card includes essential weather information, providing users with quick access to weather details for their selected locations.

#### Changes Made
1. **City Card Component**:
   - Created a `CityCard` component that takes city name and weather data as props.
   - Each card displays the city's name, current temperature, humidity, wind speed, and weather conditions.

2. **Updated `App.jsx`**:
   - Modified the main application layout to include a list of city cards for predefined cities (`Delhi`, `Jaipur`, and `Kolkata`).
   - Integrated the `fetchWeather` function to update the weather data displayed on the city cards when a card is clicked.

3. **Responsive Layout**:
   - Ensured the city cards are responsive and stack vertically on smaller screens while aligning them horizontally on larger screens.

4. **Weather Data Handling**:
   - Used `useStateContext` to retrieve and manage weather data for the selected cities.
   - Implemented a temperature conversion function to allow users to switch between Celsius and Fahrenheit.

#### Screenshots
![image](https://github.com/user-attachments/assets/109bea12-e5f6-42cd-a3c0-26dfd75e29a0)

