### PR TITLE
Fix the Bug of Showing Default value in Search Bar Even when nothing is Search

### DIFF
--- a/src/Components/SearchBar.jsx
+++ b/src/Components/SearchBar.jsx
@@ -6,7 +6,7 @@ import toast from 'react-hot-toast';
 
 function SearchBar({ setPlace }) {
   const { place } = useStateContext(); // Access place from context
-  const [input, setInput] = useState(place); // Initialize input with the current place
+  const [input, setInput] = useState(""); // Initialize input for the search element with "" as an default value when value is not provided
   const [filteredCities, setFilteredCities] = useState([]);
   const [isDropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef(null);


### PR DESCRIPTION
Early the default value for Search was provided as a Jaipur Even when user not selected but after this modification that jaipur is not displaying 